### PR TITLE
Add default settings / fix type in readme for T6install.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# RcBinaries
+RC programs without source code for the FlySky CT6-A series of transmitters. These are cheap, programmable 6 channel Chinese radios which can be used in a variety of applications.
+
+T6Config is the application that you'll want (after plugging in your radio via USB and installing the relevant driver.)
+
+This is just a fork of the original repo which contains some working settings you can use if your original ones get messed up (the T6config software is not the most user friendly.)


### PR DESCRIPTION
All in T6install.zip:
- Fixed minor typo (missing space) in readme
- Added some basic "working settings" that can be used to restore preset functionality if a config is messed up
